### PR TITLE
Add files necessary for readthedocs deployment

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+# Optionally, but recommended,
+# declare the Python requirements required to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+   install:
+   - requirements: docs/source/requirements.txt
+        

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,6 +20,7 @@ release = '0.0.2'
 
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx_copybutton"
 ]
 
 templates_path = ['_templates']

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,0 +1,4 @@
+furo
+sphinx
+sphinx-autobuild
+sphinx-copybutton


### PR DESCRIPTION
This PR added `.readthedocs.yaml` file and `requirements.txt`  file for sphinx documentation.